### PR TITLE
Use abstract key rather than description for the details of the events

### DIFF
--- a/src/app/programdsl/component/program/visitor.ts
+++ b/src/app/programdsl/component/program/visitor.ts
@@ -57,7 +57,7 @@ function calcRoot(node: Parser.Root, context: Context): object[] {
 
                         // tslint:disable-next-line:no-non-null-assertion
                         if (event!.abstract)
-                            theEvent.description = event!.abstract;
+                            theEvent.abstract = event!.abstract;
                         if (event!.type) theEvent.type = event!.type;
                         if (event!.organizers)
                             theEvent.organizers = event!.organizers;


### PR DESCRIPTION
Change the key in the generated JSON to display the details in the modal using the "abstract" 